### PR TITLE
Added ModuleManager.include() method to allow users to include module…

### DIFF
--- a/flask_bluepath/flask_bluepath.py
+++ b/flask_bluepath/flask_bluepath.py
@@ -102,4 +102,10 @@ class ModuleManager:
                 self.exclusive_modules.remove(module_name)
             self.excluded_modules.append(module_name)
 
-
+    def include(self, module_name: str):
+        '''Include a module to be loaded. If the inclusion list is not empty, only the modules in the inclusion list will be loaded.'''
+        if module_name not in self.exclusive_modules:
+            # If the module is in the exclusion list, remove it from there as a safety measure to prevent it from being excluded.
+            if module_name in self.excluded_modules:
+                self.excluded_modules.remove(module_name)
+            self.exclusive_modules.append(module_name)


### PR DESCRIPTION
…s in the loading process.

If the inclusion list is not empty, only the modules in the inclusion list will be loaded. If a module is included that is currently in the exclusion list, it will be removed from the exclusion list as a safety measure to prevent it from being excluded.

	modified:   flask_bluepath/flask_bluepath.py