### PR TITLE
Added ModuleManager.include() method to allow users to specify which …

### DIFF
--- a/flask_bluepath/flask_bluepath.py
+++ b/flask_bluepath/flask_bluepath.py
@@ -24,9 +24,9 @@ class ModuleManager:
     When initialized, it will look for directories in the specified modules directory that match the required structure and load them as modules using Flask blueprints.
     See the README for more details on the required structure of a module directory.
     '''
-    required_subdirectories = [
+
+    _minimum_module_structure = [
         'templates',
-        'static',
         'routing.py',
     ]
 
@@ -81,9 +81,9 @@ class ModuleManager:
         dir_path = os.path.join(self.abs_path_to_modules, dirname)
         if not os.path.isdir(dir_path):
             return False
-        for subdir in self.required_subdirectories:
-            if subdir not in os.listdir(dir_path):
-                print(f"    Directory {dirname} does not match module structure: Missing {subdir}\n")
+        for item in self._minimum_module_structure:
+            if item not in os.listdir(dir_path):
+                print(f"    Directory {dirname} does not match module structure: Missing {item}\n")
                 return False
         print(f"    Directory {dirname} matches module structure\n")
         return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+importlib


### PR DESCRIPTION
…modules to include in the loading process.

This provides more control over which modules are loaded, especially in cases where there are many modules and only a subset should be used.

Adjusted name of the attribute that holds the minimum module structure to be private, as it is an internal implementation detail and should not be accessed directly by users of the class. Adjusted the cotent of the minimum module structure to remove the 'static' directory, as it is not strictly required for a module to be considered valid. This allows for more flexibility in how modules are structured, while still enforcing the presence of the essential 'templates' directory and 'routing.py' file.

	modified:   flask_bluepath/flask_bluepath.py
	modified:   requirements.txt